### PR TITLE
Replace "npm ci" with "npm install"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci
+    - run: npm install
     - run: npm run compile
     - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 16
           registry-url: https://registry.npmjs.org/
       
-      - run: npm ci
+      - run: npm install
 
       - name: Create release
         env:


### PR DESCRIPTION
The `npm ci` command can only install with an existing `package-lock.json`.

Use `npm install` instead.